### PR TITLE
fix empty value as options

### DIFF
--- a/lib/Twig/Extension/HTMLHelpers.php
+++ b/lib/Twig/Extension/HTMLHelpers.php
@@ -48,7 +48,7 @@ class Twig_Extension_HTMLHelpers extends Twig_Extension
     {
         $html = "";
         foreach ($options as $key => $value) {
-            if ($key and $value) {
+            if ($key and (!is_null($value) or !is_bool($value))) {
                 $html .= " ".
                     twig_escape_filter($env, $key)."=\"".
                     twig_escape_filter($env, $value)."\"";

--- a/test/Fixtures/functions/image_tag.test
+++ b/test/Fixtures/functions/image_tag.test
@@ -3,8 +3,10 @@
 --TEMPLATE--
 {{ image_tag('image.jpg') }}
 {{ image_tag('image.jpg', {width: 100, height: 10}) }}
+{{ image_tag('image.jpg', {border: 0, title: 'hoge'}) }}
 --DATA--
 return array();
 --EXPECT--
 <img src="image.jpg" />
 <img src="image.jpg" width="100" height="10" />
+<img src="image.jpg" border="0" title="hoge" />


### PR DESCRIPTION
I wanna use some empty values for html attribute, for example `<img src="foo.pnp" border="0" />`.
But now `image_tag` returns `<img src="foo.pnp" />`:sob:.