### PR TITLE
use `html_attr` for attribute values instead of `html`

### DIFF
--- a/lib/Twig/Extension/HTMLHelpers.php
+++ b/lib/Twig/Extension/HTMLHelpers.php
@@ -51,7 +51,7 @@ class Twig_Extension_HTMLHelpers extends Twig_Extension
             if ($key and (!is_null($value) or !is_bool($value))) {
                 $html .= " ".
                     twig_escape_filter($env, $key)."=\"".
-                    twig_escape_filter($env, $value)."\"";
+                    twig_escape_filter($env, $value, 'html_attr')."\"";
             }
         }
         return $html;

--- a/test/Fixtures/functions/html_tag.test
+++ b/test/Fixtures/functions/html_tag.test
@@ -3,8 +3,10 @@
 --TEMPLATE--
 {{ html_tag('br') }}
 {{ html_tag('br', {class: 'break'}) }}
+{{ html_tag('br', {data: 'See this <b>text</b>, OK?'}) }}
 --DATA--
 return array();
 --EXPECT--
 <br />
 <br class="break" />
+<br data="See&#x20;this&#x20;&lt;b&gt;text&lt;&#x2F;b&gt;,&#x20;OK&#x3F;" />


### PR DESCRIPTION
Add a 3rd argument to `twig_escape_filter` as HTML attribute values.
See also:
- http://stackoverflow.com/questions/12038048/difference-between-escapehtml-and-escapehtml-attr-in-twig
- https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Extension/Core.php#L987
